### PR TITLE
chore: use stable TypeScript 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,14 +56,6 @@ updates:
     cooldown:
       default-days: 7
       semver-major-days: 14
-    # @typescript/native-preview ships dev releases multiple times per
-    # week; cooldown alone would block updates indefinitely. Skip its
-    # patch-bump churn — the version pin in package.json is open
-    # (`>=7.0.0-dev.0`), so users always get the latest at install.
-    ignore:
-      - dependency-name: "@typescript/native-preview"
-        update-types:
-          - version-update:semver-patch
     groups:
       npm:
         patterns:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,9 +23,10 @@ for the current scoreboard (`notes/ROADMAP.md`), open work
   all shipped in the v0.2 parity push. Parity gate: a 1000-file
   mid-migration SvelteKit workspace type-checks clean, tying upstream
   `svelte-check --tsgo` at 0 real errors.
-- **No bundled tsgo.** We discover the user's `@typescript/native-preview`
-  install in `node_modules`, preferring the platform-native binary over
-  the JS wrapper. `TSGO_BIN` env var is the override.
+- **No bundled TypeScript.** We discover the user's TypeScript 7 install in
+  `node_modules`, preferring the platform-native `tsc` binary over the JS
+  wrapper. Legacy `@typescript/native-preview` installs remain supported.
+  `TSGO_BIN` env var is the override.
 - **Upstream submodule:** `language-tools/` is a pinned submodule of
   `sveltejs/language-tools` — used as the source of truth for upstream's
   CLI behavior, the 63 `.v5` test fixtures from `svelte2tsx` that form

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 </div>
 
-Blazing fast CLI type-checker for **Svelte** projects. Drop-in replacement for [`svelte-check`](https://www.npmjs.com/package/svelte-check) — compatible flags, byte-identical diagnostics, same exit codes. Single Rust binary, powered by [`tsgo`](https://github.com/microsoft/typescript-go), incremental via `tsbuildinfo`. Built for AI agents, CI/CD, and pre-commit hooks that actually stay enabled.
+Blazing fast CLI type-checker for **Svelte** projects. Drop-in replacement for [`svelte-check`](https://www.npmjs.com/package/svelte-check) — compatible flags, byte-identical diagnostics, same exit codes. Single Rust binary, powered by TypeScript 7's native `tsc`, incremental via `tsbuildinfo`. Built for AI agents, CI/CD, and pre-commit hooks that actually stay enabled.
 
 Not an LSP, CSS linter, or formatter.
 
@@ -34,11 +34,11 @@ Diagnostic counts match `svelte-check` with same flags.
 ## Install
 
 ```sh
-npm i -D svelte-check-native @typescript/native-preview
+npm i -D svelte-check-native typescript@^7.0.0
 ```
 
-`@typescript/native-preview` is the tsgo binary — required at check
-time, never imported at runtime.
+TypeScript 7 provides the native `tsc` binary required at check time;
+it is never imported at runtime.
 
 ## Use
 
@@ -67,10 +67,10 @@ crates in one process:
 | ----------------- | ----------------------------------------------------------------------------------------------- |
 | `parser`          | Parses `.svelte` source into a Svelte-5 AST (script + template).                                |
 | `analyze`         | Semantic passes — runes, prop shapes, events, bindings, scope — feeding emit and lint.          |
-| `emit`            | Generates the `.svelte.ts` overlay tsgo will type-check. Imports rewritten so tsgo lands on it. |
+| `emit`            | Generates the `.svelte.ts` overlay TypeScript will type-check. Imports rewritten so `tsc` lands on it. |
 | `svn-lint`        | Native Rust port of `svelte/compiler`'s warning pass. Covers all known codes; no subprocess.    |
 | `svelte-compiler` | Fallback bridge to the user's `svelte/compiler` over a persistent `bun`/`node` worker pool.     |
-| `typecheck`       | Owns the tsgo overlay tsconfig + the `tsbuildinfo` cache; invokes tsgo; maps diagnostics back.  |
+| `typecheck`       | Owns the TypeScript overlay tsconfig + the `tsbuildinfo` cache; invokes `tsc`; maps diagnostics back. |
 | `core`            | Shared types (spans, diagnostics, position maps) + the canonical `TsConfig` struct.             |
 | `cli`             | Entrypoint. Flag parsing, file discovery, output formatting, exit codes.                        |
 
@@ -97,8 +97,8 @@ Every flag not listed below behaves the same as `svelte-check`.
 - `--watch` / `--preserveWatchOutput` — use [`watchexec`](https://github.com/watchexec/watchexec)
   or your editor's file watcher externally.
 - `--no-tsconfig` — errors out. A tsconfig is required.
-- `--incremental` — always on. tsgo's `tsbuildinfo` handles it.
-- `--tsgo` — always on. Classic `tsc` is not wired up.
+- `--incremental` — always on. TypeScript's `tsbuildinfo` handles it.
+- `--tsgo` — always on. TypeScript 7's native `tsc` is used.
 - `--diagnostic-sources css` — accepted but no-op (a CSS language
   service isn't bundled). Roadmap below.
 
@@ -109,9 +109,10 @@ Output defaults to `machine` when run from a coding-agent CLI:
 
 ## Environment variables
 
-- `TSGO_BIN` — override tsgo discovery; accepts an absolute path to a
-  platform-native tsgo binary. Useful when `@typescript/native-preview`
-  isn't in `node_modules` (e.g. a monorepo where tsgo lives elsewhere).
+- `TSGO_BIN` — override TypeScript discovery; accepts an absolute path to
+  a platform-native `tsc` binary. The name is retained for compatibility.
+  Useful when `typescript` isn't in `node_modules` (e.g. a monorepo where
+  TypeScript lives elsewhere).
 - `SVN_BRIDGE_WORKERS` — number of `svelte/compiler` worker
   subprocesses. Default `cores/2`, capped at 8; tracks the perf-core
   count on Apple Silicon. Override if you hit IPC contention on very
@@ -123,7 +124,7 @@ Output defaults to `machine` when run from a coding-agent CLI:
 
 - `0` — no errors (and no warnings if `--fail-on-warnings`)
 - `1` — errors detected (or warnings with `--fail-on-warnings`)
-- `2` — invocation error (bad flag, missing tsconfig, tsgo not found)
+- `2` — invocation error (bad flag, missing tsconfig, TypeScript not found)
 
 ## Roadmap
 
@@ -146,9 +147,8 @@ Iterate `T` directly in the mapped-type key instead.
   / [`svelte-check`](https://github.com/sveltejs/language-tools/tree/master/packages/svelte-check)
   — transpiler + CLI whose output shape and flags we
   match. The `.v5` fixture corpus from `svelte2tsx` is our parity gate.
-- [tsgo](https://github.com/microsoft/typescript-go) — the Go-based
-  TypeScript compiler that does the actual type-checking. Shipped as
-  `@typescript/native-preview`.
+- [TypeScript 7](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/)
+  — the native compiler that does the actual type-checking.
 
 ## License
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -29,11 +29,11 @@ use output::{print_diagnostics, print_machine_failure};
 #[command(
     name = "svelte-check-native",
     version,
-    about = "CLI-only type checker for Svelte 5+ projects. Powered by tsgo.",
+    about = "CLI-only type checker for Svelte 5+ projects. Powered by TypeScript 7.",
     long_about = "svelte-check-native — type-check Svelte components.\n\n\
                   Both Svelte 4 (export let, $:, <slot>, on:event) and Svelte 5\n\
-                  (runes) syntax are supported. tsgo (@typescript/native-preview)\n\
-                  must be installed in the project's node_modules, or pointed at\n\
+                  (runes) syntax are supported. TypeScript 7 must be installed\n\
+                  in the project's node_modules, or pointed at\n\
                   via TSGO_BIN. A tsconfig/jsconfig is required (mirrors\n\
                   `svelte-check --tsgo`); --no-tsconfig and watch mode are not\n\
                   supported."
@@ -192,8 +192,7 @@ struct Cli {
     debug_paths: bool,
 
     /// Print the resolved tsgo binary path + its --version output, then
-    /// exit. Helps verify that `@typescript/native-preview` is at the
-    /// expected version.
+    /// exit. Helps verify that TypeScript 7 is at the expected version.
     #[arg(long = "tsgo-version", default_value_t = false)]
     tsgo_version: bool,
 
@@ -604,8 +603,8 @@ fn run_tsgo_version(workspace: &Path) -> ExitCode {
         }
     };
     println!("tsgo binary: {}", &bin.path.display());
-    // The discovery layer flags JS-wrapper installs (`tsgo.js` under
-    // node_modules/@typescript/native-preview/bin/) with
+    // The discovery layer flags JS-wrapper installs (`tsc` under
+    // node_modules/typescript/bin/) with
     // `needs_node = true`. Those can't be exec'd directly — we have
     // to spawn `node <path>` instead. The main type-check path at
     // runner.rs honors this; missing it here meant

--- a/crates/cli/tests/v5_fixtures.rs
+++ b/crates/cli/tests/v5_fixtures.rs
@@ -1,7 +1,7 @@
 //! svelte2tsx `.v5` fixture parity suite.
 //!
 //! Walks the 63 Svelte-5-only fixtures from upstream svelte2tsx's test
-//! corpus and asserts our binary produces zero tsgo errors against each.
+//! corpus and asserts our binary produces zero TypeScript errors against each.
 //! Each fixture is a known-good Svelte 5 component so any error we
 //! report is a real fidelity gap.
 //!
@@ -43,13 +43,13 @@ fn v5_fixtures_suite() {
         );
 
     // Per-fixture workspaces live under /var/folders/... where there's
-    // no enclosing node_modules to walk up to. Locate the local tsgo
+    // no enclosing node_modules to walk up to. Locate the local TypeScript
     // ourselves and pass via TSGO_BIN so the binary doesn't fail in
     // discovery (which would silently inflate the pass-count).
     let tsgo = locate_local_tsgo(&crate_dir).expect(
         "could not locate the workspace's local tsgo install. \
          Run `npm install` at the repo root to install \
-         @typescript/native-preview.",
+         typescript@^7.0.0.",
     );
 
     let output = match Command::new("node")
@@ -163,7 +163,8 @@ fn parse_summary(line: &str) -> (usize, usize, usize) {
 ///
 /// The previous shape of this helper hard-coded a six-path list that
 /// covered platform-native packages + the JS wrapper but missed
-/// pnpm/bun package-store layouts (`.pnpm/@typescript+native-preview@…`)
+/// pnpm/bun package-store layouts (`.pnpm/typescript@…` and legacy
+/// `.pnpm/@typescript+native-preview@…`)
 /// — the production runtime supports those via
 /// `svn_typecheck::discovery::find_in_package_store`. Reusing the
 /// real discover() keeps test coverage aligned with shipping

--- a/crates/typecheck/src/discovery.rs
+++ b/crates/typecheck/src/discovery.rs
@@ -1,26 +1,25 @@
-//! Locate the tsgo binary.
+//! Locate the TypeScript 7 native compiler.
 //!
 //! Resolution order at each ancestor `node_modules`, closest first:
-//! 1. `TSGO_BIN` env var (absolute path to a tsgo executable or wrapper).
+//! 1. `TSGO_BIN` env var (absolute path to a `tsc` executable or wrapper).
 //! 2. The platform-native binary at
-//!    `node_modules/@typescript/native-preview-<platform>/lib/tsgo[.exe]`.
+//!    `node_modules/@typescript/typescript-<platform>/lib/tsc[.exe]`.
 //!    This skips Node.js startup overhead (~50-100 ms per check).
-//! 3. The JavaScript wrapper at
-//!    `node_modules/@typescript/native-preview/bin/tsgo.js` invoked via
-//!    `node`.
+//! 3. The JavaScript wrapper at `node_modules/typescript/bin/tsc` invoked
+//!    via `node`.
 //! 4. pnpm / bun per-package-store fallbacks:
-//!    `node_modules/.pnpm/@typescript+native-preview@*/node_modules/...`
-//!    and `node_modules/.bun/@typescript+native-preview@*/node_modules/...`.
+//!    `node_modules/.pnpm/typescript@*/node_modules/...` and
+//!    `node_modules/.bun/typescript@*/node_modules/...`.
 //!    Needed when `shamefully-hoist=false` (default in pnpm 8+) or
 //!    `symlink=false` prevents the hoisted paths above from existing.
 //!    When multiple versions are installed, the highest semver wins.
 //!
-//! `@typescript/native-preview` ships the JS wrapper and installs a
-//! platform-specific package (e.g. `native-preview-darwin-arm64`) as an
-//! optionalDependency containing the real binary. We can therefore
-//! reliably invoke the native form when one is present and fall back to
-//! the wrapper otherwise (e.g. on a platform where no native package
-//! exists).
+//! TypeScript 7 ships the JS wrapper and installs a platform-specific
+//! package (e.g. `typescript-darwin-arm64`) as an optionalDependency
+//! containing the real binary. We invoke the native form when one is
+//! present and fall back to the wrapper otherwise. The old
+//! `@typescript/native-preview` layout remains supported for existing
+//! installations.
 //!
 //! Returns a [`TsgoBinary`] handle that the runner uses to spawn the
 //! correct command (a `.js` wrapper has to be invoked via `node`; a native
@@ -28,7 +27,7 @@
 
 use std::path::{Path, PathBuf};
 
-/// A located tsgo binary, ready to spawn.
+/// A located TypeScript compiler binary, ready to spawn.
 #[derive(Debug, Clone)]
 pub struct TsgoBinary {
     /// Path to the executable or JS wrapper.
@@ -37,14 +36,14 @@ pub struct TsgoBinary {
     pub needs_node: bool,
 }
 
-/// Errors when looking for tsgo.
+/// Errors when looking for TypeScript.
 #[derive(Debug, thiserror::Error)]
 pub enum DiscoveryError {
     #[error(
-        "could not find tsgo. Install `@typescript/native-preview` as a \
+        "could not find TypeScript 7. Install `typescript` as a \
          devDependency, or set TSGO_BIN to an absolute path. Searched \
-         upward from {searched_from} for `@typescript/native-preview` \
-         (hoisted under node_modules, or isolated under .pnpm/.bun)."
+         upward from {searched_from} for `typescript` (hoisted under \
+         node_modules, or isolated under .pnpm/.bun)."
     )]
     NotFound { searched_from: PathBuf },
 
@@ -52,7 +51,7 @@ pub enum DiscoveryError {
     EnvBinNotFound { path: PathBuf },
 }
 
-/// Locate tsgo.
+/// Locate TypeScript 7, with a fallback for legacy native-preview installs.
 pub fn discover(workspace: &Path) -> Result<TsgoBinary, DiscoveryError> {
     if let Ok(env_path) = std::env::var("TSGO_BIN") {
         let path = PathBuf::from(env_path);
@@ -71,12 +70,19 @@ pub fn discover(workspace: &Path) -> Result<TsgoBinary, DiscoveryError> {
         return Ok(TsgoBinary { path, needs_node });
     }
 
-    let native_relative = current_platform_native_path();
-    let wrapper_relative = Path::new("node_modules/@typescript/native-preview/bin/tsgo.js");
+    let native_relatives = [
+        current_platform_native_path(),
+        legacy_platform_native_path(),
+    ];
+    let wrapper_relatives = [
+        Path::new("node_modules/typescript/bin/tsc"),
+        Path::new("node_modules/@typescript/native-preview/bin/tsgo.js"),
+    ];
 
     svn_core::walk_up_dirs(workspace, |dir| {
-        // Native binary is preferred — no Node.js startup overhead.
-        if let Some(rel) = &native_relative {
+        // Native binary is preferred — no Node.js startup overhead. Stable
+        // TypeScript 7 is checked before the legacy preview layout.
+        for rel in native_relatives.iter().flatten() {
             let candidate = dir.join(rel);
             if candidate.is_file() {
                 return Some(TsgoBinary {
@@ -86,101 +92,105 @@ pub fn discover(workspace: &Path) -> Result<TsgoBinary, DiscoveryError> {
             }
         }
         // Fallback: JS wrapper requires `node`.
-        let wrapper = dir.join(wrapper_relative);
-        if wrapper.is_file() {
-            return Some(TsgoBinary {
-                path: wrapper,
-                needs_node: true,
-            });
+        for rel in wrapper_relatives {
+            let wrapper = dir.join(rel);
+            if wrapper.is_file() {
+                return Some(TsgoBinary {
+                    path: wrapper,
+                    needs_node: true,
+                });
+            }
         }
         // pnpm / bun per-package store. Only reached when the
         // canonical hoisted paths above are absent (pnpm
         // `shamefully-hoist=false`, isolated installs, etc.).
-        find_in_package_store(dir, native_relative.as_deref())
+        find_in_package_store(dir, &native_relatives)
     })
     .ok_or_else(|| DiscoveryError::NotFound {
         searched_from: workspace.to_path_buf(),
     })
 }
 
-/// Look for `@typescript+native-preview@<version>` directories under
+/// Look for stable `typescript@<version>` and legacy
+/// `@typescript+native-preview@<version>` directories under
 /// `<dir>/node_modules/.pnpm` and `<dir>/node_modules/.bun`. Returns
 /// the highest-version match's native binary (preferred) or JS wrapper
-/// (fallback). Returns `None` when no package-store entries exist.
+/// (fallback). Stable TypeScript is preferred over the legacy preview.
 ///
 /// pnpm store layout (shamefully-hoist=false or symlink=false):
 ///
 /// ```text
 /// node_modules/.pnpm/
-///   @typescript+native-preview@7.0.0-dev.20260101.1/
+///   typescript@7.0.2/
 ///     node_modules/@typescript/
-///       native-preview/bin/tsgo.js
-///       native-preview-darwin-arm64/lib/tsgo
+///       typescript-darwin-arm64/lib/tsc
+///     typescript/bin/tsc
 /// ```
 ///
 /// bun uses the same layout under `.bun/`.
-fn find_in_package_store(dir: &Path, native_relative: Option<&Path>) -> Option<TsgoBinary> {
+fn find_in_package_store(
+    dir: &Path,
+    native_relatives: &[Option<PathBuf>; 2],
+) -> Option<TsgoBinary> {
     for manager_root in [
         dir.join(svn_core::NODE_MODULES_DIR).join(".pnpm"),
         dir.join(svn_core::NODE_MODULES_DIR).join(".bun"),
     ] {
-        let Ok(entries) = std::fs::read_dir(&manager_root) else {
-            continue;
-        };
-        // Collect every `@typescript+native-preview@<version>` entry
-        // and sort newest-first by parsed semver. Lexicographic sort
-        // mis-orders any segment that crosses a multi-digit boundary
-        // (`...9` beats `...10`, `9.0.0` beats `10.0.0`) — tsgo's
-        // dev-release suffix `7.0.0-dev.YYYYMMDD.N` is fine today
-        // because `N` is single-digit and the date is fixed-width, but
-        // either axis can cross 9→10 in the future and silently
-        // downgrade users to an older tsgo.
-        let mut candidates: Vec<PathBuf> = entries
-            .filter_map(|e| e.ok())
-            .map(|e| e.path())
-            .filter(|p| {
-                p.file_name()
-                    .and_then(|s| s.to_str())
-                    .is_some_and(|name| name.starts_with("@typescript+native-preview@"))
-            })
-            .collect();
-        candidates.sort_by(|a, b| {
-            let va = version_from_store_entry(a);
-            let vb = version_from_store_entry(b);
-            // Newest first. Unparseable entries sort last so a weird
-            // store subdir never shadows a real version.
-            match (va, vb) {
-                (Some(va), Some(vb)) => vb.cmp(&va),
-                (Some(_), None) => std::cmp::Ordering::Less,
-                (None, Some(_)) => std::cmp::Ordering::Greater,
-                (None, None) => b.cmp(a),
-            }
-        });
+        for (prefix, wrapper_tail) in [
+            ("typescript@", "typescript/bin/tsc"),
+            (
+                "@typescript+native-preview@",
+                "@typescript/native-preview/bin/tsgo.js",
+            ),
+        ] {
+            let Ok(entries) = std::fs::read_dir(&manager_root) else {
+                continue;
+            };
+            // Collect every version in this package family and sort
+            // newest-first by parsed semver. Lexicographic sorting would
+            // mis-order a multi-digit version or preview suffix.
+            let mut candidates: Vec<PathBuf> = entries
+                .filter_map(|e| e.ok())
+                .map(|e| e.path())
+                .filter(|p| {
+                    p.file_name()
+                        .and_then(|s| s.to_str())
+                        .is_some_and(|name| name.starts_with(prefix))
+                })
+                .collect();
+            candidates.sort_by(|a, b| {
+                let va = version_from_store_entry(a);
+                let vb = version_from_store_entry(b);
+                match (va, vb) {
+                    (Some(va), Some(vb)) => vb.cmp(&va),
+                    (Some(_), None) => std::cmp::Ordering::Less,
+                    (None, Some(_)) => std::cmp::Ordering::Greater,
+                    (None, None) => b.cmp(a),
+                }
+            });
 
-        for pkg_root in candidates {
-            let inner = pkg_root.join("node_modules/@typescript");
-            // Native binary under the sibling platform package inside
-            // the same store entry — prefer this form when present.
-            if let Some(rel) = native_relative {
-                // native_relative is rooted at `node_modules/...`; we
-                // need the tail after `node_modules/` to attach under
-                // the store's own `node_modules/`.
-                if let Ok(tail) = rel.strip_prefix("node_modules/") {
-                    let native_candidate = pkg_root.join(svn_core::NODE_MODULES_DIR).join(tail);
-                    if native_candidate.is_file() {
-                        return Some(TsgoBinary {
-                            path: native_candidate,
-                            needs_node: false,
-                        });
+            for pkg_root in candidates {
+                // Native binary under the sibling platform package inside
+                // the same store entry — prefer this form when present.
+                for rel in native_relatives.iter().flatten() {
+                    if let Ok(tail) = rel.strip_prefix("node_modules/") {
+                        let native_candidate = pkg_root.join(svn_core::NODE_MODULES_DIR).join(tail);
+                        if native_candidate.is_file() {
+                            return Some(TsgoBinary {
+                                path: native_candidate,
+                                needs_node: false,
+                            });
+                        }
                     }
                 }
-            }
-            let wrapper_candidate = inner.join("native-preview/bin/tsgo.js");
-            if wrapper_candidate.is_file() {
-                return Some(TsgoBinary {
-                    path: wrapper_candidate,
-                    needs_node: true,
-                });
+                let wrapper_candidate =
+                    pkg_root.join(svn_core::NODE_MODULES_DIR).join(wrapper_tail);
+                if wrapper_candidate.is_file() {
+                    return Some(TsgoBinary {
+                        path: wrapper_candidate,
+                        needs_node: true,
+                    });
+                }
             }
         }
     }
@@ -189,21 +199,24 @@ fn find_in_package_store(dir: &Path, native_relative: Option<&Path>) -> Option<T
 
 /// Extract and parse the version from a pnpm/bun store directory name.
 ///
-/// Store entries are named `@typescript+native-preview@<version>`. When the
-/// version is valid semver (tsgo's own `7.0.0-dev.YYYYMMDD.N` form is), the
+/// Store entries are named `typescript@<version>` or
+/// `@typescript+native-preview@<version>`. When the version is valid semver
+/// (including tsgo's own `7.0.0-dev.YYYYMMDD.N` form), the
 /// parsed [`Version`](semver::Version) sorts correctly by semver rules —
 /// `1.0.0-dev.10` > `1.0.0-dev.9` (numeric identifier compare) and
 /// `10.0.0` > `9.0.0`. Returns `None` for entries that don't match the
 /// expected name or whose version doesn't parse.
 fn version_from_store_entry(path: &Path) -> Option<semver::Version> {
     let name = path.file_name().and_then(|s| s.to_str())?;
-    let ver = name.strip_prefix("@typescript+native-preview@")?;
+    let ver = name
+        .strip_prefix("typescript@")
+        .or_else(|| name.strip_prefix("@typescript+native-preview@"))?;
     semver::Version::parse(ver).ok()
 }
 
-/// Return the relative path to the platform-native tsgo binary, or `None`
-/// if we don't know how to map the current platform to a published
-/// `@typescript/native-preview-<platform>` package.
+/// Return the relative path to the platform-native TypeScript 7 binary, or
+/// `None` if we don't know how to map the current platform to a published
+/// `@typescript/typescript-<platform>` package.
 ///
 /// Mapping mirrors the platform tags used by the npm packages:
 /// - `darwin` + `aarch64` → `darwin-arm64`
@@ -212,6 +225,26 @@ fn version_from_store_entry(path: &Path) -> Option<semver::Version> {
 /// - `linux`  + `x86_64`  → `linux-x64`
 /// - `windows`+ `x86_64`  → `win32-x64` (binary suffixed `.exe`)
 fn current_platform_native_path() -> Option<PathBuf> {
+    let platform_tag = match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("macos", "aarch64") => "darwin-arm64",
+        ("macos", "x86_64") => "darwin-x64",
+        ("linux", "aarch64") => "linux-arm64",
+        ("linux", "x86_64") => "linux-x64",
+        ("windows", "x86_64") => "win32-x64",
+        _ => return None,
+    };
+    let exe = if cfg!(windows) { "tsc.exe" } else { "tsc" };
+    Some(
+        PathBuf::from("node_modules/@typescript")
+            .join(format!("typescript-{platform_tag}"))
+            .join("lib")
+            .join(exe),
+    )
+}
+
+/// Return the legacy native-preview path for compatibility with existing
+/// installations that have not migrated to the stable `typescript` package.
+fn legacy_platform_native_path() -> Option<PathBuf> {
     let platform_tag = match (std::env::consts::OS, std::env::consts::ARCH) {
         ("macos", "aarch64") => "darwin-arm64",
         ("macos", "x86_64") => "darwin-x64",
@@ -247,6 +280,18 @@ mod tests {
 
         let found = discover(tmp.path()).unwrap();
         assert_eq!(found.path, tsgo);
+        assert!(found.needs_node);
+    }
+
+    #[test]
+    fn discovers_typescript_wrapper_in_local_node_modules() {
+        let tmp = tempdir().unwrap();
+        let wrapper = tmp.path().join("node_modules/typescript/bin/tsc");
+        fs::create_dir_all(wrapper.parent().unwrap()).unwrap();
+        fs::write(&wrapper, "#!/usr/bin/env node\n").unwrap();
+
+        let found = discover(tmp.path()).unwrap();
+        assert_eq!(found.path, wrapper);
         assert!(found.needs_node);
     }
 
@@ -345,6 +390,36 @@ mod tests {
         let found = discover(tmp.path()).unwrap();
         assert_eq!(found.path, wrapper);
         assert!(found.needs_node);
+    }
+
+    #[test]
+    fn discovers_typescript_in_pnpm_package_store_wrapper() {
+        let tmp = tempdir().unwrap();
+        let pkg_root = tmp.path().join("node_modules/.pnpm/typescript@7.0.2");
+        let wrapper = pkg_root.join("node_modules/typescript/bin/tsc");
+        fs::create_dir_all(wrapper.parent().unwrap()).unwrap();
+        fs::write(&wrapper, "#!/usr/bin/env node\n").unwrap();
+
+        let found = discover(tmp.path()).unwrap();
+        assert_eq!(found.path, wrapper);
+        assert!(found.needs_node);
+    }
+
+    #[test]
+    fn discovers_typescript_native_binary_in_pnpm_package_store() {
+        let Some(rel) = current_platform_native_path() else {
+            return;
+        };
+        let tmp = tempdir().unwrap();
+        let pkg_root = tmp.path().join("node_modules/.pnpm/typescript@7.0.2");
+        let tail = rel.strip_prefix("node_modules/").unwrap();
+        let native = pkg_root.join("node_modules").join(tail);
+        fs::create_dir_all(native.parent().unwrap()).unwrap();
+        fs::write(&native, b"native stub").unwrap();
+
+        let found = discover(tmp.path()).unwrap();
+        assert_eq!(found.path, native);
+        assert!(!found.needs_node);
     }
 
     #[test]

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "publish:all": "npm run build:all && npm run prepare-release && node scripts/publish-all.mjs"
   },
   "devDependencies": {
-    "@typescript/native-preview": ">=7.0.0-dev.0"
+    "typescript": "^7.0.2"
   }
 }

--- a/scripts/diff-emit.mjs
+++ b/scripts/diff-emit.mjs
@@ -255,37 +255,47 @@ async function ensureOurOverlay() {
 }
 
 function runTsgo(cfgPath) {
-    // Map this host's (platform, arch) to the @typescript/native-preview
-    // platform-package suffix. Mirrors what
-    // svn_typecheck::discovery::current_platform_native_path() picks
-    // at runtime; the fallback paths below also try the JS wrapper
-    // in the order tsgo's npm install resolves.
+    // Map this host's (platform, arch) to TypeScript 7's platform-package
+    // suffix. Mirrors what svn_typecheck::discovery picks at runtime;
+    // retain the preview suffixes as a fallback for older installs.
     const suffixes = (() => {
         const p = process.platform;
         const a = process.arch;
-        if (p === 'darwin' && a === 'arm64') return ['native-preview-darwin-arm64'];
-        if (p === 'darwin' && a === 'x64') return ['native-preview-darwin-x64'];
-        if (p === 'linux' && a === 'arm64') return ['native-preview-linux-arm64'];
-        if (p === 'linux' && a === 'x64') return ['native-preview-linux-x64'];
-        if (p === 'win32' && a === 'x64') return ['native-preview-win32-x64'];
+        if (p === 'darwin' && a === 'arm64') return ['typescript-darwin-arm64', 'native-preview-darwin-arm64'];
+        if (p === 'darwin' && a === 'x64') return ['typescript-darwin-x64', 'native-preview-darwin-x64'];
+        if (p === 'linux' && a === 'arm64') return ['typescript-linux-arm64', 'native-preview-linux-arm64'];
+        if (p === 'linux' && a === 'x64') return ['typescript-linux-x64', 'native-preview-linux-x64'];
+        if (p === 'win32' && a === 'x64') return ['typescript-win32-x64', 'native-preview-win32-x64'];
         return []; // unsupported → fall through to wrapper
     })();
-    let tsgo = null;
+    let tsc = null;
     let needsNode = false;
     for (const suffix of suffixes) {
         const out = spawnSync(
             'find',
-            [workspace, '-name', 'tsgo', '-path', `*${suffix}*`, '-type', 'f'],
+            [workspace, '-name', suffix.startsWith('typescript-') ? 'tsc' : 'tsgo', '-path', `*${suffix}*`, '-type', 'f'],
             { encoding: 'utf8' },
         );
         const hit = (out.stdout || '').split('\n').filter(Boolean)[0];
         if (hit) {
-            tsgo = hit;
+            tsc = hit;
             break;
         }
     }
-    if (!tsgo) {
-        // JS-wrapper fallback (`tsgo.js`); requires node to invoke.
+    if (!tsc) {
+        // JS-wrapper fallback; requires node to invoke.
+        const out = spawnSync(
+            'find',
+            [workspace, '-path', '*typescript/bin/tsc', '-type', 'f'],
+            { encoding: 'utf8' },
+        );
+        const hit = (out.stdout || '').split('\n').filter(Boolean)[0];
+        if (hit) {
+            tsc = hit;
+            needsNode = true;
+        }
+    }
+    if (!tsc) {
         const out = spawnSync(
             'find',
             [workspace, '-path', '*native-preview/bin/tsgo.js', '-type', 'f'],
@@ -293,20 +303,18 @@ function runTsgo(cfgPath) {
         );
         const hit = (out.stdout || '').split('\n').filter(Boolean)[0];
         if (hit) {
-            tsgo = hit;
+            tsc = hit;
             needsNode = true;
         }
     }
-    if (!tsgo) {
-        console.error(
-            `tsgo not found in ${workspace} for platform ${process.platform}-${process.arch}.`,
-        );
+    if (!tsc) {
+        console.error(`TypeScript not found in ${workspace} for platform ${process.platform}-${process.arch}.`);
         return '';
     }
     const args = needsNode
-        ? [tsgo, '--pretty', 'false', '-p', cfgPath]
+        ? [tsc, '--pretty', 'false', '-p', cfgPath]
         : ['--pretty', 'false', '-p', cfgPath];
-    const cmd = needsNode ? 'node' : tsgo;
+    const cmd = needsNode ? 'node' : tsc;
     const r = spawnSync(cmd, args, {
         encoding: 'utf8',
         maxBuffer: 64 * 1024 * 1024,

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -99,9 +99,9 @@ function mainPackageJson(v) {
     optionalDependencies: Object.fromEntries(
       TARGETS.map((t) => [`${MAIN_PKG}-${t.npmPlatform}`, v]),
     ),
-    peerDependencies: { '@typescript/native-preview': '>=7.0.0-dev.0' },
+    peerDependencies: { typescript: '>=7.0.0' },
     peerDependenciesMeta: {
-      '@typescript/native-preview': { optional: false },
+      typescript: { optional: false },
     },
   };
 }


### PR DESCRIPTION
## Summary

- replace the development `@typescript/native-preview` dependency with stable `typescript@^7.0.2`
- discover TypeScript 7's native `tsc` binary and wrapper layouts, while retaining legacy preview discovery
- update the published peer dependency, release metadata, documentation, and discovery coverage

## Why

TypeScript 7 is now released through the standard `typescript` package. Its native compiler is published as `tsc`, so the old preview-only package and `tsgo` paths no longer describe the supported installation.

## Validation

- `cargo test -p svn-typecheck` — 118 passed
- `cargo clippy -p svn-typecheck --all-targets -- -D warnings` — passed
- stable TypeScript 7 smoke check — `1 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS`
- `node scripts/prepare-release.mjs --check` — passed
- `node --check scripts/diff-emit.mjs` — passed
- the repository's emit snapshot suite still reports its pre-existing 0/455 hash-only mismatches on both this branch and an untouched baseline checkout
